### PR TITLE
fix: restore player state when shown again

### DIFF
--- a/src/@types/types.d.ts
+++ b/src/@types/types.d.ts
@@ -1,4 +1,10 @@
-declare type Service = 'test-service' | 'vrv' | 'funimation' | 'crunchyroll';
+declare type Service =
+  | 'test-service'
+  | 'vrv'
+  | 'funimation'
+  | 'funimation-2021-09-26'
+  | 'crunchyroll';
+
 declare type ServiceDisplayName =
   | 'Anime Skip Test'
   | 'VRV'

--- a/src/common/utils/Constants.ts
+++ b/src/common/utils/Constants.ts
@@ -285,6 +285,10 @@ export const SUPPORTED_THIRD_PARTY_SERVICES: Record<Service, Array<TimestampSour
     // Don't support BETTER_VRV because show names and durations are completely different
     source => source !== 'BETTER_VRV'
   ),
+  'funimation-2021-09-26': allTimestampSources.filter(
+    // Don't support BETTER_VRV because show names and durations are completely different
+    source => source !== 'BETTER_VRV'
+  ),
   crunchyroll: allTimestampSources,
 };
 

--- a/src/content-scripts/player/state/useVideoState.ts
+++ b/src/content-scripts/player/state/useVideoState.ts
@@ -61,12 +61,12 @@ const {
   isActive: false,
   isBuffering: true,
   isPaused: initialVideo?.paused ?? false,
-  isMuted: false,
+  isMuted: initialVideo?.muted ?? false,
   volumePercent: 100,
   allowVolumeChangeTo: undefined,
   currentTime: initialVideo?.currentTime ?? 0,
-  duration: undefined as number | undefined,
-  playbackRate: 1,
+  duration: initialVideo?.duration || (undefined as number | undefined),
+  playbackRate: initialVideo?.playbackRate ?? 1,
 });
 
 export { provideVideoState, useVideoState, useUpdateVideoState };


### PR DESCRIPTION
After returning to anime skip from the original video player, the player now restores state instead of using defaults for the video state (paused, muted, etc)