### PR TITLE
fix: removed localhost from scripts of production manifest

### DIFF
--- a/scripts/generate-manifest.ts
+++ b/scripts/generate-manifest.ts
@@ -4,7 +4,7 @@ import { Manifest } from 'webextension-polyfill';
 import {
   PAGE_ACTION_MATCHES,
   ParentHosts,
-  PlayerHosts,
+  PlayerHostsProduction,
 } from '../src/common/utils/compile-time-constants';
 import { rootPath } from './utils';
 
@@ -27,7 +27,7 @@ export function generateManifest(config: GenerateManifestConfig): Manifest.WebEx
   const name = pkg.displayName + suffixes[config.mode];
   const contentScriptMatches = new Set([
     ...Object.values(ParentHosts),
-    ...Object.values(PlayerHosts),
+    ...Object.values(PlayerHostsProduction),
   ]);
 
   return merge(manifestTemplate, {
@@ -43,7 +43,7 @@ export function generateManifest(config: GenerateManifestConfig): Manifest.WebEx
         matches: Array.from(contentScriptMatches.values()),
       },
       {
-        matches: Object.values(PlayerHosts),
+        matches: Object.values(PlayerHostsProduction),
       },
     ],
   });

--- a/src/common/utils/compile-time-constants.ts
+++ b/src/common/utils/compile-time-constants.ts
@@ -24,6 +24,17 @@ export enum PlayerHosts {
 }
 
 /**
+ * All the host permission url matchers that run the injected player scripts for production
+ */
+
+export enum PlayerHostsProduction {
+  CRUNCHYROLL = 'https://static.crunchyroll.com/vilos-v2/web/vilos/player.html*',
+  FUNIMATION = 'https://www.funimation.com/player/*',
+  FUNIMATION_20210926 = 'https://www.funimation.com/v/*',
+  VRV = 'https://static.vrv.co/*',
+}
+
+/**
  * All the URL matches to show the action for. This is a superset fo the `ParentHosts` since some of
  * those have a path specified and the action should be shown for the entire website
  */


### PR DESCRIPTION
Fixes https://github.com/anime-skip/web-extension/issues/197

Added PlayerHostsProduction enum in compile-time-constants with localhost field removed to avoid its inclusion in content scripts